### PR TITLE
[TEST] Use new flag 0x2001 for floating window

### DIFF
--- a/src/com/zst/app/multiwindowsidebar/Common.java
+++ b/src/com/zst/app/multiwindowsidebar/Common.java
@@ -7,7 +7,7 @@ public class Common {
 	public static final String PKG_THIS = Common.class.getPackage().getName();
 	
 	// Intent Launching
-	public static final int FLAG_FLOATING_WINDOW = 0x00002000;
+	public static final int FLAG_FLOATING_WINDOW = 0x00002001;
 	public static final int FLAG_XMULTIWINDOW_UPVIEW = 0x001;
 	public static final int FLAG_XMULTIWINDOW_DOWNVIEW = 0x002;
 	public static final String EXTRA_XHALO_SNAP_SIDE = PKG_XHALOFLOATINGWINDOW + ".EXTRA_SNAP_SIDE";


### PR DESCRIPTION
This is to comply with test xhfw mods. Lollipop uses the old flag (0x2000) as FLAG_ACTIVITY_RETAIN_IN_RECENTS - to keep list of documents or open pages in recent tasks when the user closes the app. It is default launch flag for the new Chrome, for example. Getting the new unused flag - 0x2001.
